### PR TITLE
Refactor to use different request method

### DIFF
--- a/astroquery/lcogt/tests/test_lcogt.py
+++ b/astroquery/lcogt/tests/test_lcogt.py
@@ -36,7 +36,7 @@ def patch_get(request):
     return mp
 
 
-def get_mockreturn(method, url, params=None, timeout=10, **kwargs):
+def get_mockreturn(method, url, params=None, timeout=10, cache=True, **kwargs):
     filename = data_path(DATA_FILES[params['spatial']])
     content = open(filename, 'rb').read()
     return MockResponse(content, **kwargs)

--- a/astroquery/lcogt/tests/test_lcogt.py
+++ b/astroquery/lcogt/tests/test_lcogt.py
@@ -20,7 +20,8 @@ DATA_FILES = {'Cone': 'Cone.xml',
               'Polygon': 'Polygon.xml'}
 
 OBJ_LIST = ["m31", "00h42m44.330s +41d16m07.50s",
-            commons.GalacticCoordGenerator(l=121.1743, b=-21.5733, unit=(u.deg, u.deg))]
+            commons.GalacticCoordGenerator(l=121.1743, b=-21.5733, unit=(u.deg,
+                                                                         u.deg))]
 
 
 def data_path(filename):
@@ -31,11 +32,11 @@ def data_path(filename):
 @pytest.fixture
 def patch_get(request):
     mp = request.getfuncargvalue("monkeypatch")
-    mp.setattr(requests, 'get', get_mockreturn)
+    mp.setattr(lcogt.core.Lcogt, '_request', get_mockreturn)
     return mp
 
 
-def get_mockreturn(url, params=None, timeout=10, **kwargs):
+def get_mockreturn(method, url, params=None, timeout=10, **kwargs):
     filename = data_path(DATA_FILES[params['spatial']])
     content = open(filename, 'rb').read()
     return MockResponse(content, **kwargs)


### PR DESCRIPTION
@zemogle I made a few changes to make this fit more with the most up to date astroquery standard (and wrap to 80 characters in most places).  The big things are:
1. `async_to_sync` does magic: `query_object` and `query_region` simply aren't needed if `query_object_async` and `query_region_async` exist
2. `commons.request` is replaces with `BaseQuery._request`, which includes caching magic.

I need to add the caching keywords, though, so don't merge for a few minutes at least...
